### PR TITLE
Disable standard JAR task to prevent broken clipboard-agent-1.0.jar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,11 @@ tasks.shadowJar.configure {
     archiveFileName.set("clipboard-agent.jar")
 }
 
+// Remove generated standard jar task (e.g., clipboard-agent-1.0.jar)
+tasks.jar {
+    enabled = false
+}
+
 tasks.build.configure {
     dependsOn(tasks.shadowJar)
 }


### PR DESCRIPTION
Gradle was generating two jar files:
 - clipboard-agent.jar	(via shadowJar)
 - clipboard-agent-1.0.jar (standard default generated by gradle)

The standard JAR lacked required dependencies and caused runtime crashes. This change disables it to ensure only the correct, shaded JAR is produced.